### PR TITLE
ci: simplify workflows and reduce Dependabot noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,15 +4,10 @@ updates:
   - package-ecosystem: "nuget"
     directory: "/app"
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: "monthly"
       time: "06:00"
       timezone: "Europe/Oslo"
-    open-pull-requests-limit: 1
-    reviewers:
-      - "flyrev"
-    assignees:
-      - "flyrev"
+    open-pull-requests-limit: 2
     commit-message:
       prefix: "chore"
       include: "scope"
@@ -23,26 +18,21 @@ updates:
     pull-request-branch-name:
       separator: "/"
     groups:
-      aws-sdk:
+      routine:
         patterns:
-          - "AWSSDK*"
-      microsoft:
-        patterns:
-          - "Microsoft.*"
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   # NuGet dependencies for the CLI tool
   - package-ecosystem: "nuget"
     directory: "/cli"
     schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "06:00"
+      interval: "monthly"
+      time: "06:15"
       timezone: "Europe/Oslo"
-    open-pull-requests-limit: 1
-    reviewers:
-      - "flyrev"
-    assignees:
-      - "flyrev"
+    open-pull-requests-limit: 2
     commit-message:
       prefix: "chore"
       include: "scope"
@@ -52,20 +42,22 @@ updates:
     rebase-strategy: "auto"
     pull-request-branch-name:
       separator: "/"
+    groups:
+      routine:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   # npm dependencies for the React frontend
   - package-ecosystem: "npm"
     directory: "/app/ClientApp"
     schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "06:00"
+      interval: "monthly"
+      time: "06:30"
       timezone: "Europe/Oslo"
-    open-pull-requests-limit: 1
-    reviewers:
-      - "flyrev"
-    assignees:
-      - "flyrev"
+    open-pull-requests-limit: 2
     commit-message:
       prefix: "chore"
       prefix-development: "chore"
@@ -76,40 +68,23 @@ updates:
     rebase-strategy: "auto"
     pull-request-branch-name:
       separator: "/"
-    versioning-strategy: "increase"
+    versioning-strategy: "increase-if-necessary"
     groups:
-      react:
+      routine:
         patterns:
-          - "react"
-          - "react-dom"
-          - "react-scripts"
-      react-router:
-        patterns:
-          - "react-router*"
-      eslint:
-        patterns:
-          - "eslint*"
+          - "*"
         update-types:
           - "minor"
           - "patch"
-      bootstrap:
-        patterns:
-          - "bootstrap"
-          - "reactstrap"
 
   # Docker base image updates
   - package-ecosystem: "docker"
     directory: "/app"
     schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "06:00"
+      interval: "monthly"
+      time: "06:45"
       timezone: "Europe/Oslo"
-    open-pull-requests-limit: 1
-    reviewers:
-      - "flyrev"
-    assignees:
-      - "flyrev"
+    open-pull-requests-limit: 2
     commit-message:
       prefix: "chore"
       include: "scope"
@@ -119,20 +94,22 @@ updates:
     rebase-strategy: "auto"
     pull-request-branch-name:
       separator: "/"
+    groups:
+      routine:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   # GitHub Actions workflows (CodeQL etc.)
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "06:00"
+      interval: "monthly"
+      time: "07:00"
       timezone: "Europe/Oslo"
-    open-pull-requests-limit: 1
-    reviewers:
-      - "flyrev"
-    assignees:
-      - "flyrev"
+    open-pull-requests-limit: 2
     commit-message:
       prefix: "chore"
       include: "scope"
@@ -142,3 +119,10 @@ updates:
     rebase-strategy: "auto"
     pull-request-branch-name:
       separator: "/"
+    groups:
+      routine:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,81 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - "README.md"
+      - "LICENSE"
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - "README.md"
+      - "LICENSE"
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    name: Verify app and CLI
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      NPM_CONFIG_AUDIT: "false"
+      NPM_CONFIG_FUND: "false"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: app/ClientApp/package-lock.json
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Install frontend dependencies
+        working-directory: app/ClientApp
+        run: npm ci
+
+      - name: Lint frontend
+        working-directory: app/ClientApp
+        run: npm run lint
+
+      - name: Test frontend
+        working-directory: app/ClientApp
+        run: npm test -- --watch=false
+
+      - name: Restore web app
+        run: dotnet restore app/FortniteReplayAnalyzer.csproj
+
+      - name: Publish web app
+        run: dotnet publish app/FortniteReplayAnalyzer.csproj --configuration Release --no-restore
+
+      - name: Restore CLI
+        run: dotnet restore cli/cli.csproj
+
+      - name: Build CLI
+        run: dotnet build cli/cli.csproj --configuration Release --no-restore
+
+  docker:
+    name: Build Docker image
+    runs-on: ubuntu-latest
+    needs: verify
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Build Docker image
+        run: docker build --file app/Dockerfile --tag fortnite-replay-analyzer-ci app

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,47 +3,77 @@ name: CodeQL
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - "README.md"
+      - "LICENSE"
   pull_request:
     branches: [main]
+    paths-ignore:
+      - "README.md"
+      - "LICENSE"
   schedule:
-    - cron: "0 6 * * 1" # Monday 06:00 UTC, aligned with dependabot schedule
+    - cron: "0 6 * * 1" # Monday 06:00 UTC
+  workflow_dispatch:
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
 
 jobs:
-  analyze:
-    name: Analyze
+  analyze-csharp:
+    name: Analyze C#
     runs-on: ubuntu-latest
-    permissions:
-      security-events: write
-      contents: read
-      actions: read
-    strategy:
-      fail-fast: false
-      matrix:
-        language: [csharp, javascript-typescript]
+    timeout-minutes: 30
+    env:
+      NPM_CONFIG_AUDIT: "false"
+      NPM_CONFIG_FUND: "false"
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 8.0.x
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4
         with:
-          languages: ${{ matrix.language }}
-
-      - name: Setup .NET
-        if: matrix.language == 'csharp'
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: 8.0.x
+          languages: csharp
+          build-mode: manual
 
       - name: Build C# projects
-        if: matrix.language == 'csharp'
         run: |
           dotnet restore app/FortniteReplayAnalyzer.csproj
-          dotnet build app/FortniteReplayAnalyzer.csproj --no-restore
+          dotnet build app/FortniteReplayAnalyzer.csproj --configuration Release --no-restore
           dotnet restore cli/cli.csproj
-          dotnet build cli/cli.csproj --no-restore
+          dotnet build cli/cli.csproj --configuration Release --no-restore
 
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@v4
         with:
-          category: "/language:${{ matrix.language }}"
+          category: /language:csharp
+
+  analyze-javascript:
+    name: Analyze JavaScript/TypeScript
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: javascript-typescript
+          build-mode: none
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: /language:javascript-typescript

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,5 +1,15 @@
 name: Dependabot auto-merge
-on: pull_request
+
+on:
+  pull_request_target:
+    branches: [main]
+    types: [opened, reopened, synchronize]
+    paths:
+      - "app/ClientApp/package.json"
+      - "app/ClientApp/package-lock.json"
+      - "app/FortniteReplayAnalyzer.csproj"
+      - "cli/cli.csproj"
+      - "app/Dockerfile"
 
 permissions:
   contents: write
@@ -8,7 +18,7 @@ permissions:
 jobs:
   dependabot:
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]'
+    if: github.actor == 'dependabot[bot]' && contains(join(github.event.pull_request.labels.*.name, ','), 'dependencies')
     steps:
       - name: Auto-merge Dependabot PRs
         run: gh pr merge --auto --merge "$PR_URL"

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,4 +1,6 @@
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build-env
+ENV NPM_CONFIG_AUDIT=false \
+    NPM_CONFIG_FUND=false
 RUN apt-get update -y
 RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
 RUN apt-get install nodejs -yq
@@ -7,11 +9,11 @@ WORKDIR /app
 
 # Copy csproj and restore as distinct layers
 COPY *.csproj ./
-RUN dotnet restore
+RUN dotnet restore FortniteReplayAnalyzer.csproj
 
 # Copy everything else and build
 COPY . ./
-RUN dotnet publish -c Release -o out
+RUN dotnet publish FortniteReplayAnalyzer.csproj -c Release -o out
 
 # Build runtime image
 FROM mcr.microsoft.com/dotnet/aspnet:8.0


### PR DESCRIPTION
## Summary
- add a single `CI` workflow that covers frontend checks, app publish, CLI build, and a Docker image build so the repo has one clear verification path
- modernize the `CodeQL` workflow with explicit C# and JS jobs, newer setup actions, concurrency, and explicit build modes to reduce noise and avoid outdated runner behavior
- cut Dependabot noise by switching routine updates to monthly grouped PRs, removing reviewer/assignee spam, and limiting auto-merge automation to manifest-only dependency PRs

## Testing
- `ruby -e 'require "yaml"; YAML.load_file("/Users/christian/Fortnite-Replay-Analyzer/.github/workflows/ci.yml"); YAML.load_file("/Users/christian/Fortnite-Replay-Analyzer/.github/workflows/codeql.yml"); YAML.load_file("/Users/christian/Fortnite-Replay-Analyzer/.github/workflows/dependabot-auto-merge.yml"); YAML.load_file("/Users/christian/Fortnite-Replay-Analyzer/.github/dependabot.yml"); puts "all yaml ok"'`
- `npm ci --prefix app/ClientApp`
- `npm run lint --prefix app/ClientApp`
- `npm test --prefix app/ClientApp -- --watch=false`
- `dotnet publish app/FortniteReplayAnalyzer.csproj --configuration Release --no-restore`
- `dotnet build cli/cli.csproj --configuration Release --no-restore`
- `docker build --file app/Dockerfile --tag fortnite-replay-analyzer-ci app`
- `docker run -d --rm -p 18080:8080 --name fra-ci-smoke fortnite-replay-analyzer-ci:latest && sleep 5 && curl -fsS -o /dev/null -w '%{http_code}\\n' http://127.0.0.1:18080/ && docker stop fra-ci-smoke >/dev/null`

## Notes
- The auto-merge workflow now ignores GitHub Actions-only Dependabot PRs so workflow changes stay visible for review instead of merging automatically.