### PR TITLE
ci: automate Dependabot cleanup and major-upgrade triage

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -21,7 +21,7 @@ jobs:
     if: github.actor == 'dependabot[bot]' && contains(join(github.event.pull_request.labels.*.name, ','), 'dependencies')
     steps:
       - name: Auto-merge Dependabot PRs
-        run: gh pr merge --auto --merge "$PR_URL"
+        run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependabot-major-upgrade-assist.yml
+++ b/.github/workflows/dependabot-major-upgrade-assist.yml
@@ -1,0 +1,178 @@
+name: Dependabot major upgrade assist
+
+on:
+  workflow_run:
+    workflows: ["CI", "CodeQL"]
+    types: [completed]
+  schedule:
+    - cron: "0 */6 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: dependabot-major-upgrade-assist-${{ github.event_name }}-${{ github.event.workflow_run.id || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  actions: read
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  request-help:
+    name: Request upgrade guidance for failed major bumps
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'failure'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Ask Copilot for targeted major-upgrade guidance
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const botLogins = new Set(['app/dependabot', 'dependabot[bot]']);
+            const relevantFailureConclusions = new Set(['action_required', 'failure', 'startup_failure', 'timed_out']);
+
+            function isRelevantCheck(name) {
+              return /^Verify app and CLI$/.test(name) ||
+                /^Build Docker image$/.test(name) ||
+                /^Analyze /.test(name) ||
+                /^CI$/.test(name) ||
+                /^CodeQL$/.test(name);
+            }
+
+            function getMajorUpgrade(text) {
+              const match = text.match(/from\s+v?(\d+)(?:\.\d+){0,3}\s+to\s+v?(\d+)(?:\.\d+){0,3}/i);
+              if (!match) {
+                return null;
+              }
+
+              const fromMajor = Number(match[1]);
+              const toMajor = Number(match[2]);
+
+              if (!Number.isFinite(fromMajor) || !Number.isFinite(toMajor) || toMajor <= fromMajor) {
+                return null;
+              }
+
+              return { fromMajor, toMajor };
+            }
+
+            async function listCandidatePrs() {
+              if (context.eventName === 'workflow_run') {
+                const run = context.payload.workflow_run;
+                let prs = run.pull_requests || [];
+
+                if (!prs.length && run.head_branch) {
+                  const response = await github.rest.pulls.list({
+                    owner,
+                    repo,
+                    state: 'open',
+                    head: `${owner}:${run.head_branch}`,
+                    per_page: 20,
+                  });
+                  prs = response.data.map((pr) => ({ number: pr.number }));
+                }
+
+                return prs.map((pr) => pr.number);
+              }
+
+              const prs = await github.paginate(github.rest.pulls.list, {
+                owner,
+                repo,
+                state: 'open',
+                per_page: 100,
+              });
+
+              return prs.map((pr) => pr.number);
+            }
+
+            const candidateNumbers = [...new Set(await listCandidatePrs())];
+            let commentedCount = 0;
+
+            for (const pullNumber of candidateNumbers) {
+              const { data: pr } = await github.rest.pulls.get({
+                owner,
+                repo,
+                pull_number: pullNumber,
+              });
+
+              if (!botLogins.has(pr.user?.login || '')) {
+                continue;
+              }
+
+              const upgrade = getMajorUpgrade(`${pr.title}\n${pr.body || ''}`);
+              if (!upgrade) {
+                continue;
+              }
+
+              const checksResponse = await github.rest.checks.listForRef({
+                owner,
+                repo,
+                ref: pr.head.sha,
+                per_page: 100,
+              });
+
+              const failedChecks = checksResponse.data.check_runs.filter((check) => {
+                return check.status === 'completed' &&
+                  relevantFailureConclusions.has(check.conclusion) &&
+                  isRelevantCheck(check.name);
+              });
+
+              if (!failedChecks.length) {
+                continue;
+              }
+
+              const marker = `<!-- dependabot-major-upgrade-assist:${pr.head.sha} -->`;
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner,
+                repo,
+                issue_number: pullNumber,
+                per_page: 100,
+              });
+
+              if (comments.some((comment) => (comment.body || '').includes(marker))) {
+                continue;
+              }
+
+              const files = await github.paginate(github.rest.pulls.listFiles, {
+                owner,
+                repo,
+                pull_number: pullNumber,
+                per_page: 100,
+              });
+
+              const dependencyMatch = pr.title.match(/Bump\s+(.+?)\s+from\s+/i);
+              const dependencyName = dependencyMatch ? dependencyMatch[1] : 'this dependency';
+              const failedCheckLines = failedChecks.map((check) => `- ${check.name}: ${check.html_url}`);
+              const changedFiles = files.map((file) => `\`${file.filename}\``).join(', ');
+
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: pullNumber,
+                body: [
+                  marker,
+                  '@copilot this Dependabot PR is a major upgrade and the automated checks are failing.',
+                  '',
+                  'Please review the failure and suggest the smallest code or configuration changes needed to make this upgrade pass without changing unrelated behavior.',
+                  '',
+                  `Context:`,
+                  `- PR: #${pullNumber} (${pr.title})`,
+                  `- Dependency: ${dependencyName}`,
+                  `- Version jump: ${upgrade.fromMajor} -> ${upgrade.toMajor}`,
+                  `- Changed files: ${changedFiles || 'n/a'}`,
+                  '- Failed checks:',
+                  ...failedCheckLines,
+                  '',
+                  'Please comment with:',
+                  '1. likely breaking changes behind the failure',
+                  '2. the minimal edits needed to restore the build',
+                  '3. whether the upgrade should be deferred instead',
+                ].join('\n'),
+              });
+
+              commentedCount += 1;
+            }
+
+            core.info(`Reviewed ${candidateNumbers.length} candidate PR(s); requested guidance on ${commentedCount}.`);

--- a/.github/workflows/dependabot-pr-hygiene.yml
+++ b/.github/workflows/dependabot-pr-hygiene.yml
@@ -1,0 +1,103 @@
+name: Dependabot PR hygiene
+
+on:
+  schedule:
+    - cron: "30 7 * * 1-5"
+  workflow_dispatch:
+
+concurrency:
+  group: dependabot-pr-hygiene
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  close-superseded:
+    name: Close superseded Dependabot PRs
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Close older PRs in crowded dependency groups
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const keepCount = 2;
+            const staleAfterDays = 7;
+            const now = Date.now();
+            const botLogins = new Set(['app/dependabot', 'dependabot[bot]']);
+
+            const prs = await github.paginate(github.rest.pulls.list, {
+              owner,
+              repo,
+              state: 'open',
+              per_page: 100,
+            });
+
+            const dependabotPrs = prs.filter((pr) => botLogins.has(pr.user?.login || ''));
+            const groups = new Map();
+
+            for (const pr of dependabotPrs) {
+              const files = await github.paginate(github.rest.pulls.listFiles, {
+                owner,
+                repo,
+                pull_number: pr.number,
+                per_page: 100,
+              });
+
+              const fileNames = files.map((file) => file.filename).sort();
+              const fallbackKey = pr.head.ref.split('/').slice(0, -1).join('/');
+              const key = fileNames.join('|') || fallbackKey;
+              const group = groups.get(key) || [];
+
+              group.push({
+                pr,
+                fileNames,
+              });
+
+              groups.set(key, group);
+            }
+
+            let closedCount = 0;
+
+            for (const group of groups.values()) {
+              group.sort((left, right) => new Date(right.pr.created_at) - new Date(left.pr.created_at));
+
+              for (const entry of group.slice(keepCount)) {
+                const ageDays = (now - new Date(entry.pr.created_at).getTime()) / 86400000;
+
+                if (ageDays < staleAfterDays) {
+                  continue;
+                }
+
+                const fileSummary = entry.fileNames.map((file) => `\`${file}\``).join(', ');
+
+                await github.rest.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number: entry.pr.number,
+                  body: [
+                    '<!-- dependabot-pr-hygiene -->',
+                    'Closing this older Dependabot PR because newer PRs are already open for the same dependency manifest set.',
+                    '',
+                    `Affected files: ${fileSummary || 'same dependency group'}`,
+                    `Policy: keep the newest ${keepCount} PRs per dependency group and let older superseded bot PRs age out after ${staleAfterDays} days.`,
+                  ].join('\n'),
+                });
+
+                await github.rest.pulls.update({
+                  owner,
+                  repo,
+                  pull_number: entry.pr.number,
+                  state: 'closed',
+                });
+
+                closedCount += 1;
+              }
+            }
+
+            core.info(`Reviewed ${dependabotPrs.length} Dependabot PR(s) across ${groups.size} group(s); closed ${closedCount}.`);


### PR DESCRIPTION
## Summary
- add a scheduled Dependabot PR hygiene workflow that closes older superseded bot PRs once newer PRs exist for the same manifest group
- add a major-upgrade assist workflow that comments on failing major Dependabot PRs with an `@copilot` request for the minimal changes needed to get CI back to green
- switch Dependabot auto-merge to `--squash` so the bot uses the repository's working merge path instead of failing on the previous merge mode

## Testing
- `ruby -e 'require "yaml"; YAML.load_file("/Users/christian/Fortnite-Replay-Analyzer/.github/workflows/dependabot-auto-merge.yml"); YAML.load_file("/Users/christian/Fortnite-Replay-Analyzer/.github/workflows/dependabot-pr-hygiene.yml"); YAML.load_file("/Users/christian/Fortnite-Replay-Analyzer/.github/workflows/dependabot-major-upgrade-assist.yml"); puts "workflow yaml ok"'`

## Notes
- the Copilot assist workflow only reacts to real build and analysis failures (`CI`, `Verify app and CLI`, `Build Docker image`, `CodeQL`, `Analyze ...`) so noisy platform checks like `submit-nuget` do not trigger upgrade triage comments
- the hygiene workflow keeps the newest two Dependabot PRs per manifest group and only closes older ones after they have been open for at least seven days